### PR TITLE
Updated version for model in openai-models.bicep

### DIFF
--- a/infra-as-code/bicep/openai-models.bicep
+++ b/infra-as-code/bicep/openai-models.bicep
@@ -24,7 +24,7 @@ resource openAiAccount 'Microsoft.CognitiveServices/accounts@2023-10-01-preview'
       model: {
         format: 'OpenAI'
         name: 'gpt-35-turbo'
-        version: ''
+        version: '0613' // If your region doesn't support this version, please change it.
       }
       raiPolicyName: openAiAccount::blockingFilter.name
       versionUpgradeOption: 'OnceNewDefaultVersionAvailable'

--- a/infra-as-code/bicep/openai-models.bicep
+++ b/infra-as-code/bicep/openai-models.bicep
@@ -24,7 +24,7 @@ resource openAiAccount 'Microsoft.CognitiveServices/accounts@2023-10-01-preview'
       model: {
         format: 'OpenAI'
         name: 'gpt-35-turbo'
-        version: '0613'
+        version: ''
       }
       raiPolicyName: openAiAccount::blockingFilter.name
       versionUpgradeOption: 'OnceNewDefaultVersionAvailable'


### PR DESCRIPTION
Updated version for model in openai-models.bicep so that the default is used. Does not work in some regions to use 0613. If left empty, the default version will be used.