### PR TITLE
topic (orchestrator): [fw] add production readiness note for fw rules

### DIFF
--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -120,7 +120,8 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
     }
   }
 
-  @description('Add rules for the Azure AI agent egress and jump boxes subnets. Extend to support other subnets as needed.')
+  @descriptiou('Add rules for the Azure AI agent egress and jump boxes subnets. Extend to support other subnets as needed.')
+
   resource applicationRules 'ruleCollectionGroups' = {
     name: 'DefaultApplicationRuleCollectionGroup'
     properties: {
@@ -134,6 +135,28 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
             type: 'Allow'
           }
           rules: [
+            // Production readiness change: refine your rule sets to restrict egress traffic exclusively to the external services and endpoints your agent depends on. The following application rule demonstrates how to scope access specifically to Grounding with Bing.
+            // {
+            //   ruleType: 'ApplicationRule'
+            //   name: 'allow-groundingwithbing'
+            //   description: 'Supports required communication for the Azure Monitor addon in AKS'
+            //   protocols: [
+            //     {
+            //       protocolType: 'Https'
+            //       port: 443
+            //     }
+            //   ]
+            //   fqdnTags: []
+            //   webCategories: []
+            //   targetFqdns: [
+            //     'api.bing.microsoft.com'
+            //   ]
+            //   targetUrls: []
+            //   terminateTLS: false
+            //   sourceAddresses: ['${virtualNetwork::agentsEgressSubnet.properties.addressPrefix}']
+            //   destinationAddresses: []
+            //   httpHeadersToInsert: []
+            // }
             {
               ruleType: 'ApplicationRule'
               name: 'allow-dependencies'
@@ -228,7 +251,7 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
             id: virtualNetwork::firewall.id
           }
         }
-        
+
       }
     ]
     firewallPolicy: {

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -232,7 +232,6 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
             id: virtualNetwork::firewall.id
           }
         }
-
       }
     ]
     firewallPolicy: {

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -181,7 +181,7 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
               ]
               fqdnTags: []
               webCategories: []
-              targetFqdns: ['*']
+              targetFqdns: ['*'] // Production readiness change: specify target FQDNs to ensure only approved resources can be accessed from your jumpbox.
               targetUrls: []
               terminateTLS: false
               sourceAddresses: ['${virtualNetwork::jumpBoxesSubnet.properties.addressPrefix}']

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -135,28 +135,6 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
             type: 'Allow'
           }
           rules: [
-            // Production readiness change: refine your rule sets to restrict egress traffic exclusively to the external services and endpoints your agent depends on. The following application rule demonstrates how to scope access specifically to Grounding with Bing.
-            // {
-            //   ruleType: 'ApplicationRule'
-            //   name: 'allow-groundingwithbing'
-            //   description: 'Supports required communication for the Grounding with Bing in Azure AI Agents Service'
-            //   protocols: [
-            //     {
-            //       protocolType: 'Https'
-            //       port: 443
-            //     }
-            //   ]
-            //   fqdnTags: []
-            //   webCategories: []
-            //   targetFqdns: [
-            //     'api.bing.microsoft.com'
-            //   ]
-            //   targetUrls: []
-            //   terminateTLS: false
-            //   sourceAddresses: ['${virtualNetwork::agentsEgressSubnet.properties.addressPrefix}']
-            //   destinationAddresses: []
-            //   httpHeadersToInsert: []
-            // }
             {
               ruleType: 'ApplicationRule'
               name: 'allow-dependencies'
@@ -168,7 +146,10 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
               ]
               fqdnTags: []
               webCategories: []
-              targetFqdns: ['*']
+              targetFqdns: [
+                 '*'
+                 // 'api.bing.microsoft.com' // Production readiness change: refine your target FQDNs to restrict egress traffic exclusively to the external services and endpoints your agent depends on. For instance this fqnd scopes access specifically to Grounding with Bing.
+              ]
               targetUrls: []
               terminateTLS: false
               sourceAddresses: ['${virtualNetwork::agentsEgressSubnet.properties.addressPrefix}']

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -139,7 +139,7 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
             // {
             //   ruleType: 'ApplicationRule'
             //   name: 'allow-groundingwithbing'
-            //   description: 'Supports required communication for the Azure Monitor addon in AKS'
+            //   description: 'Supports required communication for the Grounding with Bing in Azure AI Agents Service'
             //   protocols: [
             //     {
             //       protocolType: 'Https'

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -111,7 +111,7 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
               name: 'allow-dependencies'
               ipProtocols: ['Any']
               sourceAddresses: ['${virtualNetwork::jumpBoxesSubnet.properties.addressPrefix}']
-              destinationAddresses: ['*']
+              destinationAddresses: ['*'] // Production readiness change: tighten destination address to ensure egress traffic is restricted to the minimal required spaces.
               destinationPorts: ['*']
             }
           ]


### PR DESCRIPTION
## WHY 

we wanted to have a realistic application fw rule for Grounding with Bing as a production readiness note. This will help platform teams to quickly realize how to configure this but also to start conversation on what should be their own rules.

## WHAT Changed?

- added a TODO with the actual rule for Grounding with Bing

## Test

no test is required for this 