### PR TITLE
feat (infra): [foundryai] udpate rp api version to the latest

### DIFF
--- a/infra-as-code/bicep/ai-foundry-project.bicep
+++ b/infra-as-code/bicep/ai-foundry-project.bicep
@@ -137,7 +137,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing
 // ---- New resources ----
 
 @description('Existing Azure AI Foundry account. The project will be created as a child resource of this account.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing  = {
+resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' existing  = {
   name: existingAiFoundryName
 
   resource project 'projects' = {

--- a/infra-as-code/bicep/ai-foundry.bicep
+++ b/infra-as-code/bicep/ai-foundry.bicep
@@ -59,7 +59,7 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02
 // ---- New resources ----
 
 @description('Deploy Azure AI Foundry (account) with Foundry Agent Service capability.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
+resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: aiFoundryName
   location: location
   kind: 'AIServices'


### PR DESCRIPTION
## WHY

We wanted to test that using the very latest version avaible it was in a deployable state the current bicep files but also ensure the networking injection field is still requiring an array or a json object

## WHAT Changed

- cs rp api version to `2025-06-01`

## TEST

array is still required

<img width="3431" height="58" alt="image" src="https://github.com/user-attachments/assets/2841e61c-0511-40f9-aa73-867dd2ccb20b" />

<img width="434" height="210" alt="image" src="https://github.com/user-attachments/assets/238ef4ea-1022-4db5-82c3-f02a3cb018d4" />