### PR TITLE
feat (infra): [sec] support multiple principals when creating role assignments

### DIFF
--- a/infra-as-code/bicep/ai-foundry-project.bicep
+++ b/infra-as-code/bicep/ai-foundry-project.bicep
@@ -238,7 +238,7 @@ module projectDbCosmosDbOperatorAssignment './modules/cosmosdbRoleAssignment.bic
   params: {
     roleDefinitionId: cosmosDbOperatorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingCosmosDbAccountName: existingCosmosDbAccountName
   }
 }
@@ -249,7 +249,7 @@ module projectBlobDataContributorAssignment './modules/storageAccountRoleAssignm
   params: {
     roleDefinitionId: storageBlobDataContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingStorageAccountName: existingStorageAccountName
   }
 }
@@ -260,7 +260,7 @@ module projectBlobDataOwnerConditionalAssignment './modules/storageAccountRoleAs
   params: {
     roleDefinitionId: storageBlobDataOwnerRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingStorageAccountName: existingStorageAccountName
     conditionVersion: '2.0'
     condition: '((!(ActionMatches{\'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\'})  AND  !(ActionMatches{\'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/filter/action\'}) AND  !(ActionMatches{\'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write\'}) ) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringStartsWithIgnoreCase \'${workspaceIdAsGuid}\'))'
@@ -273,7 +273,7 @@ module projectAISearchContributorAssignment './modules/aiSearchRoleAssignment.bi
   params: {
     roleDefinitionId: azureAISearchServiceContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingAISearchAccountName: existingAISearchAccountName
   }
 }
@@ -284,7 +284,7 @@ module projectAISearchIndexDataContributorAssignment './modules/aiSearchRoleAssi
   params: {
     roleDefinitionId: azureAISearchIndexDataContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingAISearchAccountName: existingAISearchAccountName
   }
 }
@@ -297,7 +297,7 @@ module projectUserThreadContainerWriterSqlAssignment './modules/cosmosdbSqlRoleA
   params: {
     roleDefinitionId: cosmosDbAccount::dataContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingCosmosDbAccountName: existingCosmosDbAccountName
     existingCosmosDbName: 'enterprise_memory'
     existingCosmosCollectionTypeName: 'user'
@@ -314,7 +314,7 @@ module projectSystemThreadContainerWriterSqlAssignment './modules/cosmosdbSqlRol
   params: {
     roleDefinitionId: cosmosDbAccount::dataContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingCosmosDbAccountName: existingCosmosDbAccountName
     existingCosmosDbName: 'enterprise_memory'
     existingCosmosCollectionTypeName: 'system'
@@ -332,7 +332,7 @@ module projectEntityContainerWriterSqlAssignment './modules/cosmosdbSqlRoleAssig
   params: {
     roleDefinitionId: cosmosDbAccount::dataContributorRole.id
     principalId: aiFoundry::project.identity.principalId
-    existingAiFoundryName: existingAiFoundryName
+    existingAiFoundryProjectId: aiFoundry::project.id
     existingCosmosDbAccountName: existingCosmosDbAccountName
     existingCosmosDbName: 'enterprise_memory'
     existingCosmosCollectionTypeName: 'entities'

--- a/infra-as-code/bicep/modules/aiSearchRoleAssignment.bicep
+++ b/infra-as-code/bicep/modules/aiSearchRoleAssignment.bicep
@@ -11,9 +11,9 @@ param roleDefinitionId string
 @description('The principalId property of the managed identity.')
 param principalId string
 
-@description('The existing Azure AI Foundry account. This project will become a child resource of this account.')
+@description('The existing Azure AI Foundry Project Id.')
 @minLength(2)
-param existingAiFoundryName string
+param existingAiFoundryProjectId string
 
 @description('The existing Azure AI Search account that is going to be used as the Azure AI Foundry Agent vector store (dependency).')
 @minLength(1)
@@ -24,18 +24,9 @@ resource azureAISearchService 'Microsoft.Search/searchServices@2025-02-01-previe
   name: existingAISearchAccountName
 }
 
-@description('Existing Azure AI Foundry account. The project will be created as a child resource of this account.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' existing  = {
-  name: existingAiFoundryName
-
-  resource project 'projects' existing = {
-    name: 'projchat'
-  }
-}
-
 // ---- Role assignment ----
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aiFoundry::project.id, azureAISearchService.id, principalId, roleDefinitionId)
+  name: guid(resourceGroup().id, existingAiFoundryProjectId, azureAISearchService.id, principalId, roleDefinitionId)
   scope: azureAISearchService
   properties: {
     roleDefinitionId: roleDefinitionId

--- a/infra-as-code/bicep/modules/cosmosdbRoleAssignment.bicep
+++ b/infra-as-code/bicep/modules/cosmosdbRoleAssignment.bicep
@@ -11,9 +11,9 @@ param roleDefinitionId string
 @description('The principalId property of the managed identity.')
 param principalId string
 
-@description('The existing Azure AI Foundry account. This project will become a child resource of this account.')
+@description('The existing Azure AI Foundry Project Id.')
 @minLength(2)
-param existingAiFoundryName string
+param existingAiFoundryProjectId string
 
 @description('The name of the existing Cosmos Db resource.')
 param existingCosmosDbAccountName string
@@ -23,18 +23,9 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2025-05-01-previ
   name: existingCosmosDbAccountName
 }
 
-@description('Existing Azure AI Foundry account. The project will be created as a child resource of this account.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' existing  = {
-  name: existingAiFoundryName
-
-  resource project 'projects' existing = {
-    name: 'projchat'
-  }
-}
-
 // ---- Role assignment ----
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aiFoundry::project.id, cosmosDbAccount.id, principalId, roleDefinitionId)
+  name: guid(resourceGroup().id, existingAiFoundryProjectId, cosmosDbAccount.id, principalId, roleDefinitionId)
   scope: cosmosDbAccount
   properties: {
     roleDefinitionId: roleDefinitionId

--- a/infra-as-code/bicep/modules/cosmosdbSqlRoleAssignment.bicep
+++ b/infra-as-code/bicep/modules/cosmosdbSqlRoleAssignment.bicep
@@ -11,9 +11,9 @@ param roleDefinitionId string
 @description('The principalId property of the managed identity.')
 param principalId string
 
-@description('The existing Azure AI Foundry account. This project will become a child resource of this account.')
+@description('The existing Azure AI Foundry Project Id.')
 @minLength(2)
-param existingAiFoundryName string
+param existingAiFoundryProjectId string
 
 @description('The name of the existing Cosmos Db resource.')
 param existingCosmosDbAccountName string
@@ -32,23 +32,14 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2025-05-01-previ
   name: existingCosmosDbAccountName
 }
 
-@description('Existing Azure AI Foundry account. The project will be created as a child resource of this account.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' existing  = {
-  name: existingAiFoundryName
-
-  resource project 'projects' existing = {
-    name: 'projchat'
-  }
-}
-
 // ---- Role assignment ----
 @description('Assign the project\'s managed identity the ability to read and write data in this collection within enterprise_memory database.')
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2025-05-01-preview' = {
-  name: guid(resourceGroup().id, aiFoundry::project.id, principalId, roleDefinitionId, existingCosmosDbName, existingCosmosCollectionTypeName)
+  name: guid(resourceGroup().id, existingAiFoundryProjectId, principalId, roleDefinitionId, existingCosmosDbName, existingCosmosCollectionTypeName)
   parent: cosmosDbAccount
   properties: {
     roleDefinitionId: roleDefinitionId
-    principalId: aiFoundry::project.identity.principalId
+    principalId: principalId
     scope: scopeUserContainerId
   }
 }

--- a/infra-as-code/bicep/modules/storageAccountRoleAssignment.bicep
+++ b/infra-as-code/bicep/modules/storageAccountRoleAssignment.bicep
@@ -11,9 +11,9 @@ param roleDefinitionId string
 @description('The principalId property of the managed identity.')
 param principalId string
 
-@description('The existing Azure AI Foundry account. This project will become a child resource of this account.')
+@description('The existing Azure AI Foundry Project Id.')
 @minLength(2)
-param existingAiFoundryName string
+param existingAiFoundryProjectId string
 
 @description('The existing Azure Storage account that is going to be used as the Azure AI Foundry Agent blob store (dependency).')
 @minLength(3)
@@ -30,18 +30,9 @@ resource agentStorageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' exis
   name: existingStorageAccountName
 }
 
-@description('Existing Azure AI Foundry account. The project will be created as a child resource of this account.')
-resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-06-01' existing  = {
-  name: existingAiFoundryName
-
-  resource project 'projects' existing = {
-    name: 'projchat'
-  }
-}
-
 // ---- Role assignment ----
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, aiFoundry::project.id, agentStorageAccount.id, principalId, roleDefinitionId)
+  name: guid(resourceGroup().id, existingAiFoundryProjectId, agentStorageAccount.id, principalId, roleDefinitionId)
   scope: agentStorageAccount
   properties: {
     roleDefinitionId: roleDefinitionId


### PR DESCRIPTION
## WHY

we wanted to support multiple/different principals role assignments for Azure Cosmos Db account, Azure Storage Account and Azure AI Search resources. This way re-deploy of AI Foundry accounts with system-assigned identities after a deletion incident is supported (recreate, not mutate, each role assignment).

## WHAT

- composite the AI Foundry Project identity principal id in the role assignment name when creating the resource
- create new modules for role assignments and sql role assignments so the principal id from the AI Foundry project can be passed as argument

## TEST
previous system-assigned are now listed as unknown/orphaned after AI Foundry account re-deploy and new system-assigned is assigned with the same roles:

<img width="842" height="114" alt="image" src="https://github.com/user-attachments/assets/a60e045f-77e9-4957-b155-5169ac120bf7" />

<img width="1027" height="126" alt="image" src="https://github.com/user-attachments/assets/7e0f8565-c7de-4dfb-8ce7-54ec1ef4834d" />

<img width="1020" height="283" alt="image" src="https://github.com/user-attachments/assets/c13c66cd-2720-4c58-bcc1-f2cf9110f047" />

roles assignments are created from modules

<img width="610" height="311" alt="image" src="https://github.com/user-attachments/assets/ca4bb82e-1b76-4bee-8fbc-698bf62488b8" />
