### PR TITLE
patch(website): [refact] resolve agent through MAF instead of Foundry SDK Agents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Microsoft Foundry hosts Foundry Agent Service as a capability. Foundry Agent ser
 
 ### Deploying an agent into Microsoft Foundry Agent service
 
-Project-scoped agents are created and managed through the Foundry [Agents REST API](https://learn.microsoft.com/rest/api/aifoundry/aiproject#agents), which is the underlying primitive for agent lifecycle operations. The Microsoft Foundry portal and the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects) consume this API. Agent invocation at runtime uses a different API surface, the [OpenAI Conversations](https://learn.microsoft.com/rest/api/aifoundry/aiproject#conversations) and [Responses](https://learn.microsoft.com/rest/api/aifoundry/aiproject#responses-94) APIs, as described in the [invocation section below](#invoking-the-agent-from-net-code-hosted-in-an-azure-web-app). [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) uses exclusively these OpenAI APIs, identifying the agent by name and version directly in the request body. Since the data plane to Foundry is private, all of these operations are restricted to being executed from within a private network connected to the private endpoint of Foundry.
+Project-scoped agents are created and managed through the Foundry [Agents REST API](https://learn.microsoft.com/rest/api/aifoundry/aiproject#agents), which is the underlying primitive for agent lifecycle operations. The Microsoft Foundry portal and the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects) consume this API. Since the data plane to Foundry is private, all of these operations are restricted to being executed from within a private network connected to the private endpoint of Foundry.
 
 Ideally agents should be source-controlled and a versioned asset. You then can deploy agents in a coordinated way with the rest of your workload's code. In this deployment guide, you'll create an agent from the jump box to simulate a deployment pipeline which could have created the agent.
 
@@ -54,6 +54,8 @@ If using the Foundry portal is desired, then the web browser experience must be 
 ### Invoking the agent from .NET code hosted in an Azure Web App
 
 A chat UI application is deployed into a private Azure App Service. The UI is accessed through Application Gateway (WAF). The .NET code uses the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) with the Foundry provider to connect to the workload's agent through the project-scoped endpoint. At this scope, applications can choose between Microsoft Agent Framework or the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects). When invoking published agent endpoints, applications should opt for Microsoft Agent Framework. The project-scoped endpoint is accessed through the Foundry private endpoint within the virtual network. Published agent endpoints share the same Foundry account FQDN and are also reachable through the same private endpoint.
+
+Agent invocation at runtime uses a different API surface than agent lifecycle management. [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) uses exclusively the [OpenAI Conversations](https://learn.microsoft.com/rest/api/aifoundry/aiproject#conversations) and [Responses](https://learn.microsoft.com/rest/api/aifoundry/aiproject#responses-94) APIs, identifying the agent by name and version directly in the request body.
 
 ## Deployment guide
 

--- a/README.md
+++ b/README.md
@@ -251,10 +251,12 @@ The AI agent definition would likely be deployed from your application's pipelin
    # Persist the agent
    az rest -u $FOUNDRY_AGENT_URL -m "post" --resource "https://ai.azure.com" -b @chat-with-bing-output.json
 
-   # Capture the Agent's ID
-   $AGENT_ID="$(az rest -u $FOUNDRY_AGENT_URL -m 'get' --resource 'https://ai.azure.com' --query last_id -o tsv)"
+   # Capture the agent's name and latest version
+   $AGENT_RESPONSE=$(az rest -u $FOUNDRY_AGENT_URL -m 'get' --resource 'https://ai.azure.com' -o json)
+   $AGENT_ID=$($AGENT_RESPONSE | ConvertFrom-Json).last_id
+   $AGENT_VERSION=$($AGENT_RESPONSE | ConvertFrom-Json).data[-1].versions.latest.version
 
-   echo $AGENT_ID
+   echo "$AGENT_ID (version $AGENT_VERSION)"
    ```
 
    | :information: | You’ve just persisted a new versioned agent in Foundry AI Agent Service, including its instructions, tools, and model. The platform has stored a canonical agent definition in the `enterprise_memory` database, making the agent addressable, executable and ready for evaluation. At this stage, the agent is available for validation, and has the `unpublished` state. Because this is your first agent, this step is also when the Foundry project provisions a default agent identity blueprint and a default agent identity for your project in Microsoft Entra Agent ID. All `unpublished` agents within the same Foundry project share this default agent identity until they are `published`.|
@@ -374,7 +376,7 @@ For this deployment guide, you'll continue using your jump box to simulate part 
 1. Update the app configuration to use the agent you deployed.
 
    ```powershell
-   az webapp config appsettings set -n "app-${BASE_NAME}" -g $RESOURCE_GROUP --settings AIAgentId="${AGENT_ID}"
+   az webapp config appsettings set -n "app-${BASE_NAME}" -g $RESOURCE_GROUP --settings AIAgentId="${AGENT_ID}" AIAgentVersion="${AGENT_VERSION}"
    ```
 
 1. Restart the web app to load the site code and its updated configuration.

--- a/infra-as-code/bicep/web-app.bicep
+++ b/infra-as-code/bicep/web-app.bicep
@@ -221,6 +221,7 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
       ApplicationInsightsAgent_EXTENSION_VERSION: '~3'
       AIProjectEndpoint:  foundry::project.properties.endpoints['AI Foundry API']
       AIAgentId: 'Not yet set' // Will be set once the agent is created
+      AIAgentVersion: 'Not yet set' // Will be set once the agent is created
       XDT_MicrosoftApplicationInsights_Mode: 'Recommended'
     }
   }

--- a/website/chatui/Configuration/ChatApiOptions.cs
+++ b/website/chatui/Configuration/ChatApiOptions.cs
@@ -9,4 +9,7 @@ public class ChatApiOptions
 
     [Required]
     public string AIAgentId { get; init; } = default!;
+
+    [Required]
+    public string AIAgentVersion { get; init; } = default!;
 }

--- a/website/chatui/Configuration/FoundryAgentResolver.cs
+++ b/website/chatui/Configuration/FoundryAgentResolver.cs
@@ -1,4 +1,5 @@
 using Azure.AI.Projects;
+using Azure.AI.Extensions.OpenAI;
 using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.Options;
 
@@ -12,7 +13,6 @@ public class FoundryAgentResolver : IDisposable
     private readonly IOptionsMonitor<ChatApiOptions> _options;
     private readonly IDisposable? _changeToken;
     private volatile FoundryAgent? _agent;
-    private string? _agentId;
 
     public FoundryAgentResolver(AIProjectClient projectClient, IOptionsMonitor<ChatApiOptions> options)
     {
@@ -21,18 +21,17 @@ public class FoundryAgentResolver : IDisposable
         _changeToken = options.OnChange(_ => Interlocked.Exchange(ref _agent, null));
     }
 
-    public async Task<FoundryAgent> GetAgentAsync()
+    public FoundryAgent GetAgent()
     {
         var current = _agent;
         if (current is not null)
             return current;
 
-        var id = _options.CurrentValue.AIAgentId;
-        var record = await _projectClient.AgentAdministrationClient.GetAgentAsync(id);
-        var agent = _projectClient.AsAIAgent(record);
+        var name = _options.CurrentValue.AIAgentId;
+        var version = _options.CurrentValue.AIAgentVersion;
+        var agent = _projectClient.AsAIAgent(new AgentReference(name, version));
 
         _agent = agent;
-        _agentId = id;
         return agent;
     }
 

--- a/website/chatui/Controllers/ChatController.cs
+++ b/website/chatui/Controllers/ChatController.cs
@@ -5,6 +5,8 @@ using chatui.Configuration;
 
 namespace chatui.Controllers;
 
+#pragma warning disable OPENAI001 // FoundryAgent is experimental
+
 [ApiController]
 [Route("[controller]/[action]")]
 public class ChatController(
@@ -20,8 +22,7 @@ public class ChatController(
             throw new ArgumentException("Message cannot be null, empty, or whitespace.", nameof(message));
         logger.LogDebug("Prompt received {Prompt}", message);
 
-        #pragma warning disable OPENAI001 // FoundryAgent is experimental
-        FoundryAgent agent = await agentResolver.GetAgentAsync();
+        FoundryAgent agent = agentResolver.GetAgent();
 
         var innerAgent = agent.GetService<ChatClientAgent>()!;
         var session = await innerAgent.CreateSessionAsync(conversationId);
@@ -34,8 +35,7 @@ public class ChatController(
     public async Task<IActionResult> Conversations()
     {
         // TODO [performance efficiency] Delay creating a conversation until the first user message arrives.
-        #pragma warning disable OPENAI001 // FoundryAgent is experimental
-        FoundryAgent agent = await agentResolver.GetAgentAsync();
+        FoundryAgent agent = agentResolver.GetAgent();
 
         var session = await agent.CreateConversationSessionAsync();
 

--- a/website/chatui/appsettings.json
+++ b/website/chatui/appsettings.json
@@ -13,5 +13,6 @@
   },
   "AllowedHosts": "*",
   "AIProjectEndpoint": "https://<foundryaccount-customsubdomain-name>.services.ai.azure.com/api/projects/<foundry-project-name>",
-  "AIAgentId": ""
+  "AIAgentId": "",
+  "AIAgentVersion": ""
 }


### PR DESCRIPTION
## WHY

While working on #99, we realize agent resolution can be done saving an api call. The web application was using the Foundry SDK's `AgentAdministrationClient.GetAgentAsync()` to resolve the agent at startup, which calls the Agents REST API (`GET /agents/{agentId}`). This is unnecessary because MAF's `AsAIAgent(AgentReference)` accepts the agent name and version directly and passes them to the OpenAI Responses API at runtime. The Foundry SDK types (`AIProjectClient`, `AgentReference`) remain as transitive dependencies exposed through MAF's API surface, but the application no longer makes any direct Foundry SDK API calls.

## WHAT

- Replaced Foundry SDK agent resolution with MAF-only `AsAIAgent(AgentReference)`
- Added `AIAgentVersion` app setting and corresponding Bicep and README updates
- minor doc improvement (move sentences around)

## TEST

<img width="2970" height="1400" alt="image" src="https://github.com/user-attachments/assets/cd30d818-2723-43a1-8d53-22907507413d" />

