### PR TITLE
feat (iac): [foundry] update Azure OpenAI model to GPT-5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,12 @@ The AI agent definition would likely be deployed from your application's pipelin
    $chat_agent.definition.model = $MODEL_CONNECTION_NAME
    $chat_agent.definition.tools[0].bing_grounding.search_configurations[0].project_connection_id = $BING_CONNECTION_ID
 
-   $chat_agent | ConvertTo-Json -Depth 10 | Set-Content .\chat-with-bing-output.json
+   $AGENT_BODY = $chat_agent | ConvertTo-Json -Depth 10 -Compress
+   $AGENT_BODY = $AGENT_BODY -replace '":','": '
+   $AGENT_BODY = $AGENT_BODY.Replace('"','\"')
 
    # Persist the agent
-   az rest -u $FOUNDRY_AGENT_URL -m "post" --resource "https://ai.azure.com" -b @chat-with-bing-output.json
+   az rest -u $FOUNDRY_AGENT_URL -m "post" --resource "https://ai.azure.com" -b $AGENT_BODY
 
    # Capture the agent's name and latest version
    $AGENT_RESPONSE=$(az rest -u $FOUNDRY_AGENT_URL -m 'get' --resource 'https://ai.azure.com' -o json)

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The AI agent definition would likely be deployed from your application's pipelin
    $FOUNDRY_PROJECT_NAME="projchat"
    $MODEL_CONNECTION_NAME="agent-model"
    $BING_CONNECTION_ID="$(az cognitiveservices account show -n $FOUNDRY_NAME -g $RESOURCE_GROUP --query 'id' --out tsv)/projects/${FOUNDRY_PROJECT_NAME}/connections/${BING_CONNECTION_NAME}"
-   $FOUNDRY_AGENT_URL="https://${FOUNDRY_NAME}.services.ai.azure.com/api/projects/${FOUNDRY_PROJECT_NAME}/agents?api-version=2025-11-15-preview"
+   $FOUNDRY_AGENT_URL="https://${FOUNDRY_NAME}.services.ai.azure.com/api/projects/${FOUNDRY_PROJECT_NAME}/agents?api-version=v1"
 
    echo $BING_CONNECTION_ID
    echo $MODEL_CONNECTION_NAME

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Follow these instructions to deploy this example to your Azure subscription, try
     - App Service Plans: P1v3 (AZ), 3 instances
     - Azure AI Search (S - Standard): 1
     - Azure Cosmos DB: 1 account
-    - OpenAI model: GPT-4.1 model deployment with 50k tokens per minute (TPM) capacity
+    - OpenAI model: GPT-5.4 model deployment with 50k tokens per minute (TPM) capacity
     - DDoS Protection Plans: 1
     - Public IPv4 Addresses - Standard: 4
     - Standard DSv3 Family vCPU: 2

--- a/infra-as-code/bicep/ai-foundry.bicep
+++ b/infra-as-code/bicep/ai-foundry.bicep
@@ -100,8 +100,8 @@ resource foundry 'Microsoft.CognitiveServices/accounts@2026-03-01' = {
     properties: {
       model: {
         format: 'OpenAI'
-        name: 'gpt-4.1'
-        version: '2025-04-14'  // Use a model version available in your region.
+        name: 'gpt-5.4'
+        version: '2026-03-05'  // Use a model version available in your region.
       }
       versionUpgradeOption: 'NoAutoUpgrade' // Production deployments should not auto-upgrade models.  Testing compatibility is important.
       raiPolicyName: 'Microsoft.DefaultV2'  // If this isn't strict enough for your use case, create a custom RAI policy.


### PR DESCRIPTION
## WHY

This baseline demonstrates Foundry Agent Service workflows that plan, reason across multiple steps, and invoke tools. Microsoft recommends GPT-5 models for advanced enterprise agent scenarios that prioritize structured reasoning, orchestration, and reliable tool use.
                                                                                                                                                                                                                 GPT-4.1 remains preferable for latency-sensitive, high-throughput chat, so this is a capability-driven update rather than a lifecycle extension. GPT-5.4 version `2026-03-05` retires on March 5, 2027, compared with April 14, 2027 for GPT-4.1 version `2025-04-14`. 

## WHAT
   - [x] Update the deployed model to GPT-5.4 `2026-03-05` 
   - [x] Update the documented model quota prerequisite

## TEST

e2e passed

<img width="1028" height="168" alt="image" src="https://github.com/user-attachments/assets/721799ea-7430-4778-9648-021e8393047a" />
<img width="2980" height="216" alt="image" src="https://github.com/user-attachments/assets/203a9488-ab62-4877-861b-0fb199415e54" />
<img width="3002" height="1426" alt="image" src="https://github.com/user-attachments/assets/1d6b81d5-943f-4791-bdea-557563a48cf0" />
